### PR TITLE
Parameters update and size reduction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Steps are defined and ordered to reduce the number and the size of layers.
 # You can verify the size of every layer by using "docker history <img>".
 # We need a JDK. And we need a minimalist OS.
-FROM openjdk:7-jdk-alpine
+FROM openjdk:7-jre-alpine
 
 # Roboconf dockerfile
 LABEL maintainer="The Roboconf Team" \
@@ -39,7 +39,7 @@ COPY start.sh /opt/${pkgname}-docker-wrapper.sh
 #
 # * Install temporarily wget and SSL stuff.
 # * Download the Roboconf distribution and unpack it
-# * Configure Karaf
+# * Configure Karaf ($JAVA_HOME is correctly configured in the base image)
 # * Allow the local client to connect to Karaf instances (keys.properties)
 # Remove temporary packages
 RUN apk add --no-cache --virtual .bootstrap-deps wget ca-certificates && \
@@ -50,7 +50,6 @@ RUN apk add --no-cache --virtual .bootstrap-deps wget ca-certificates && \
 	tar -zxf ${fullname}.tar.gz && \
 	ln -s ${fullname}-* ${fullname} && \
 	rm -f ${fullname}.tar.gz ${fullname}.tar.gz.sha1 && \
-	echo "export JAVA_HOME=/usr/lib/jvm/java-1.7-openjdk" >> /opt/${fullname}/bin/setenv && \
 	mv /opt/${pkgname}-docker-wrapper.sh /opt/${fullname}/ && \
 	chmod 775 /opt/${fullname}/${pkgname}-docker-wrapper.sh && \
 	sed -i 's/#karaf/karaf/g' /opt/${fullname}/etc/keys.properties && \

--- a/meta-scripts/build.sh
+++ b/meta-scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 Linagora, Université Joseph Fourier, Floralis
+# Copyright 2016-2017 Linagora, Université Joseph Fourier, Floralis
 #
 # The present code is developed in the scope of the joint LINAGORA - Université
 # Joseph Fourier - Floralis research program and is designated as a "Result"

--- a/meta-scripts/inspect-container.sh
+++ b/meta-scripts/inspect-container.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2015-2016 Linagora, Université Joseph Fourier, Floralis
+# Copyright 2015-2017 Linagora, Université Joseph Fourier, Floralis
 #
 # The present code is developed in the scope of the joint LINAGORA -
 # Université Joseph Fourier - Floralis research program and is designated

--- a/meta-scripts/verify.sh
+++ b/meta-scripts/verify.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 Linagora, Université Joseph Fourier, Floralis
+# Copyright 2016-2017 Linagora, Université Joseph Fourier, Floralis
 #
 # The present code is developed in the scope of the joint LINAGORA - Université
 # Joseph Fourier - Floralis research program and is designated as a "Result"

--- a/readme.md
+++ b/readme.md
@@ -138,11 +138,37 @@ Environment variables are the same than for the DM, with the following ones in a
 
 | Variable | Value | Description |
 | -------- | :---: | ----------- |
-| AGENT_TARGET_ID | - | The target ID. Used to determine whether dynamic parameters are available. |
+| AGENT_PARAMETERS | - | The agent parameters. Used to determine whether and where dynamic parameters are available. |
 | AGENT_APPLICATION_NAME | - | The application's name. |
 | AGENT_SCOPED_INSTANCE_PATH | - | The path of the instance associated with this agent. |
 | AGENT_IP_ADDRESS_OF_THE_AGENT | - | To force the IP address of an agent (if not set, will be deduced). |
 
+> Using **AGENT_PARAMETERS** implies all the configuration is passed dynamically
+> by the DM. When used, you do not have to pass other environment variables.
+> Parameters will be retrieved dynamically (including the messaging stuff).
+
+Here are examples showing how to use this image.  
+
+```bash
+# Force the agent parameters
+$ docker run -d -p 8181:8181 \
+         -e AGENT_APPLICATION_NAME="my application name" \
+         -e AGENT_SCOPED_INSTANCE_PATH="/vm1/app1" \
+         -e AGENT_IP_ADDRESS_OF_THE_AGENT="192.168.1.19" \
+         roboconf/roboconf-agent:latest
+
+# Dynamic parameters passed through user data
+$ docker run -d -p 8181:8181 \
+         -e AGENT_PARAMETERS="@iaas-ec2" \
+         roboconf/roboconf-agent:latest
+
+# Dynamic parameters passed through a file
+# (used as an example by the DM when it launches agents in Docker containers).
+$ docker run -d -p 8181:8181 \
+         -v /tmp/rbf:/tmp/dynamic-parameters \
+         -e AGENT_PARAMETERS="/tmp/dynamic-parameters/user-data.txt" \
+         roboconf/roboconf-agent:latest
+```
 
 
 How to build this image
@@ -176,7 +202,8 @@ docker build \
 		--build-arg RBCF_KIND=agent \
 		--build-arg RBCF_VERSION=0.6 \
 		-t roboconf/roboconf-agent:latest \
-		-t roboconf/roboconf-agent:0.6 .
+		-t roboconf/roboconf-agent:0.6 \
+		.
 ```
 
 To release a snapshot version...
@@ -192,7 +219,7 @@ docker build \
 ```
 
 > By setting 2 tags, the latest tag will be updated on every release.    
-> And older versions will remained tagged.
+> And older tags/versions will remain.
 
 It is also possible to build images for the latest versions.  
 But it is only recommended for development. Not to be pushed to Docker hub.
@@ -202,7 +229,7 @@ To build the last released version of Roboconf (if the version is not specified,
 ```
 docker build \
 		--build-arg RBCF_KIND=agent \
-		-t roboconf/roboconf-agent:latest
+		-t roboconf/roboconf-agent:latest \
 		.
 ```
 
@@ -212,12 +239,13 @@ To build the last snapshot version of Roboconf (if the version is not specified,
 docker build \
 		--build-arg RBCF_KIND=agent \
 		--build-arg MAVEN_POLICY=snapshots \
-		-t roboconf/roboconf-agent:latest
+		-t roboconf/roboconf-agent:latest \
 		.
 ```
 
 Please, refer to the [official Docker documentation](https://docs.docker.com/engine/reference/commandline/build/) for alternatives.
 
+> Once images are built for both the DM and the agent, you can run tests with the **verify.sh** script.
 
 
 License

--- a/start.sh
+++ b/start.sh
@@ -68,21 +68,21 @@ fi
 
 file=etc/net.roboconf.agent.configuration.cfg
 if [ -f $file ]; then
-	
-	agent_target_id=""
+
+	agent_parameters=""
 	agent_application_name=""
 	agent_scoped_instance_path=""
 	agent_ip_address_of_the_agent=""
 
-	[ ! -z "$AGENT_TARGET_ID" ] && agent_target_id="$AGENT_TARGET_ID"
+	[ ! -z "$AGENT_PARAMETERS" ] && agent_parameters="$AGENT_PARAMETERS"
 	[ ! -z "$AGENT_APPLICATION_NAME" ] && agent_application_name="$AGENT_APPLICATION_NAME"
 	[ ! -z "$AGENT_SCOPED_INSTANCE_PATH" ] && agent_scoped_instance_path="$AGENT_SCOPED_INSTANCE_PATH"
 	[ ! -z "$AGENT_IP_ADDRESS_OF_THE_AGENT" ] && agent_ip_address_of_the_agent="$AGENT_IP_ADDRESS_OF_THE_AGENT"
-	
-	sed -i "s/target-id\s*=.*/target-id = ${agent_target_id}/g" $file
+
+	sed -i "s/parameters\s*=.*/parameters = ${agent_parameters}/g" $file
 	sed -i "s/application-name\s*=.*/application-name = ${agent_application_name}/g" $file
 	sed -i "s/ip-address-of-the-agent\s*=.*/ip-address-of-the-agent = ${agent_ip_address_of_the_agent}/g" $file
-	
+
 	# "agent_scoped_instance_path" generally contains slashes. So, we use ~ as the SED separator.
 	sed -i "s~scoped-instance-path\s*=.*~scoped-instance-path = ${agent_scoped_instance_path}~g" $file
 fi

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-# /bin/bash
+#!/bin/bash
 
 #
 # RabbitMQ configuration


### PR DESCRIPTION
This PR needs roboconf/roboconf-platform#801 to be merged first.
This is due to the renaming of a parameter in the agent's configuration.

Size reduction is quite impressive.
Locally, `docker images` shows that **roboconf/roboconf-agent** takes 386 MB. With the new modifications in the Dockerfile, it drops to 175 MB. Once compressed on Docker Hub, we may hope for an image of 100 MB. We might even gain a little more by using a JRE image instead of a JDK.